### PR TITLE
Sign images with Cosign

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
+[*.json]
+indent_style = space
+indent_size = 4
+
 [*.md]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,3 +96,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
         if: github.ref == 'refs/heads/main' || matrix.version == '37'  # We only want the latest version for testing
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v2
+
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image
+        run: |
+          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
+          cosign sign --key cosign.key ghcr.io/${{ github.repository_owner }}/${{ steps.build.outputs.image }}@${{ steps.push.outputs.digest }}
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        if: github.ref == 'refs/heads/main' || matrix.version == '37'

--- a/src/Kinoite.containerfile
+++ b/src/Kinoite.containerfile
@@ -15,6 +15,9 @@ ARG FEDORA_VERSION=37
 # See https://pagure.io/releng/pull-request/11180 for final location of base image
 FROM ghcr.io/cgwalters/fedora-kinoite:$FEDORA_VERSION
 
+# Copy configuration files
+COPY ./etc /etc
+
 # Finish and commit image
 RUN rpm-ostree cleanup -m && \
     ostree container commit

--- a/src/Silverblue.containerfile
+++ b/src/Silverblue.containerfile
@@ -15,6 +15,9 @@ ARG FEDORA_VERSION=37
 # See https://pagure.io/releng/pull-request/11180 for final location of base image
 FROM ghcr.io/cgwalters/fedora-silverblue:$FEDORA_VERSION
 
+# Copy configuration files
+COPY ./etc /etc
+
 # Finish and commit image
 RUN rpm-ostree cleanup -m && \
     ostree container commit

--- a/src/etc/containers/policy.json
+++ b/src/etc/containers/policy.json
@@ -1,0 +1,83 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "registry.redhat.io": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "ghcr.io/ahgencer/silverblue": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/etc/pki/containers/ocitree.pub",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                }
+            ],
+            "ghcr.io/ahgencer/kinoite": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/etc/pki/containers/ocitree.pub",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                }
+            ],
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-daemon": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "atomic": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "oci": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "tarball": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/src/etc/containers/registries.d/ocitree.yaml
+++ b/src/etc/containers/registries.d/ocitree.yaml
@@ -1,0 +1,5 @@
+docker:
+  ghcr.io/ahgencer/silverblue:
+    use-sigstore-attachments: true
+  ghcr.io/ahgencer/kinoite:
+    use-sigstore-attachments: true

--- a/src/etc/pki/containers/ocitree.pub
+++ b/src/etc/pki/containers/ocitree.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnJEh0T2c+4saH2BDmWhq/XuWhqeG
+akLGeWgCtA609gRKYSyblP0nmtO/LqSZt3BsTmYAfxHnwTenJXeFdC8a+w==
+-----END PUBLIC KEY-----


### PR DESCRIPTION
This PR tracks the efforts to sign the published images using [Cosign](https://docs.sigstore.dev/cosign/overview/) and rebase to the signed image with `ostree-image-signed`.

Here's the current progress so far:

- Extended the `publish.yml` action to install and sign the images with Cosign. The image signatures are stored alongside the images on the container registry, and can be verified locally with `cosign verify`. The private key is stored in a GitHub Secret, which means a new private key needs to be configured for forks of this repository.
- Configured `containers-policy.json(5)` and `containers-registries.d(5)` to specify the path to the public key `ocitree.pub`. When pulling the images with `podman pull`, the signatures are verified as expected.

Now, the remaining problem is to get `rpm-ostree` to verify the signature during a rebase / upgrade. For some reason, it doesn't reject images with incorrect or no signatures, even though it rebases to `ostree-image-signed:<IMAGE>` just fine. For now, I filed https://github.com/coreos/rpm-ostree/issues/4272 to see if this is a bug.